### PR TITLE
Glitch Fish & Preserve Aspect

### DIFF
--- a/Assets/Scenes/3_Beta/5_BETA_Fishing.unity
+++ b/Assets/Scenes/3_Beta/5_BETA_Fishing.unity
@@ -7408,7 +7408,7 @@ MonoBehaviour:
       m_Calls: []
   m_Sprite: {fileID: 0}
   m_Type: 0
-  m_PreserveAspect: 0
+  m_PreserveAspect: 1
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1

--- a/Assets/Scripts/Inventory/ScriptableObjects/Passives/Movement/DashResetsJumpFish.asset
+++ b/Assets/Scripts/Inventory/ScriptableObjects/Passives/Movement/DashResetsJumpFish.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _itemID: 13
   _itemName: Glitch Fish
-  _itemDescription: Resets jump on dash | Whoever said being a glitch was a bad thing.
+  _itemDescription: Resets jump on dash | Whoever said being a glitch was a bad thing?
   _sprite: {fileID: 21300000, guid: 625521cfb452d934290ed5a606a02654, type: 3}
   _itemPrefab: {fileID: 7580751328250549230, guid: e6e1071161c47d149b011f1e8cc0c65d, type: 3}
   _cost: 400

--- a/Assets/Scripts/Inventory/ScriptableObjects/Passives/Movement/DashResetsJumpFish.asset
+++ b/Assets/Scripts/Inventory/ScriptableObjects/Passives/Movement/DashResetsJumpFish.asset
@@ -13,9 +13,9 @@ MonoBehaviour:
   m_Name: DashResetsJumpFish
   m_EditorClassIdentifier: 
   _itemID: 13
-  _itemName: DashResetsJumpFish
-  _itemDescription: ' Dash Resets Jump'
+  _itemName: Glitch Fish
+  _itemDescription: Resets jump on dash | Whoever said being a glitch was a bad thing.
   _sprite: {fileID: 21300000, guid: 625521cfb452d934290ed5a606a02654, type: 3}
   _itemPrefab: {fileID: 7580751328250549230, guid: e6e1071161c47d149b011f1e8cc0c65d, type: 3}
-  _cost: 0
+  _cost: 400
   itemType: 2


### PR DESCRIPTION
Added description and price for the dash reset fish, which we named Glitch Fish. Also enabled Preserve Aspect for when the catch is displayed during fishing. This way, the sprites are not distorted.